### PR TITLE
Add module for creating streams to page through APIs with pagination available

### DIFF
--- a/lib/http.ex
+++ b/lib/http.ex
@@ -37,7 +37,7 @@ defmodule ExTV.HTTP do
     case response do
       nil                        -> {:error, :no_data}
       %{status_code: 200} = resp -> {:ok, resp}
-      _                          -> {:error, :bad_response}
+      _                          -> {:error, :bad_response, response}
     end
   end
 

--- a/lib/http.ex
+++ b/lib/http.ex
@@ -33,6 +33,14 @@ defmodule ExTV.HTTP do
       ]
   end
 
+  def handle_response(response) do
+    case response do
+      nil                        -> {:error, :no_data}
+      %{status_code: 200} = resp -> {:ok, resp}
+      _                          -> {:error, :bad_response}
+    end
+  end
+
   defp timeout do
     Application.get_env(:extv, :http_timeout, @default_timeout)
   end

--- a/lib/series.ex
+++ b/lib/series.ex
@@ -38,7 +38,7 @@ defmodule ExTV.Series do
   end
 
   @doc """
-  Fetches an array of episodes for the given series id
+  Fetches an enumerable of episodes for the given series id
 
   ## Parameters
 

--- a/lib/series.ex
+++ b/lib/series.ex
@@ -43,15 +43,17 @@ defmodule ExTV.Series do
   ## Parameters
 
     - id: the ID of the series on theTVDB.com
+    - raise_on_error: Raise if there is an error
+    end
   """
-  @spec episodes(number) :: Enumerable.t
-  def episodes(id) do
+  @spec episodes(number, boolean) :: Enumerable.t
+  def episodes(id, raise_on_error \\ false) do
     fetch_page = fn page ->
       get!("series/#{id}/episodes?page=#{page}")
       |> handle_response()
     end
 
-    stream(fetch_page)
+    stream(fetch_page, &default_extract/1, &default_next_page/2, [raise: raise_on_error])
   end
 
   @doc """

--- a/lib/series.ex
+++ b/lib/series.ex
@@ -6,6 +6,7 @@ defmodule ExTV.Series do
   """
 
   import ExTV.HTTP
+  import ExTV.Streamable
 
   @doc """
   Fetches information about a single TV series.
@@ -43,9 +44,14 @@ defmodule ExTV.Series do
 
     - id: the ID of the series on theTVDB.com
   """
-  @spec episodes(number) :: map() | nil
+  @spec episodes(number) :: Enumerable.t
   def episodes(id) do
-    get!("series/#{id}/episodes").body["data"]
+    fetch_page = fn page ->
+      get!("series/#{id}/episodes?page=#{page}")
+      |> handle_response()
+    end
+
+    stream(fetch_page)
   end
 
   @doc """

--- a/lib/streamable.ex
+++ b/lib/streamable.ex
@@ -1,0 +1,67 @@
+defmodule ExTV.Streamable do
+  @spec stream((integer -> map()), (map() -> map()), (integer, map() -> integer)) :: Enumerable.t
+  def stream(fetch_page, extract_data \\ &default_extract/1, calc_next_page \\ &default_next_page/2) do
+    start_fn = fn ->
+      start(fetch_page, extract_data, calc_next_page)
+    end
+
+    next_fn = fn state ->
+      next_item(fetch_page, extract_data, calc_next_page, state)
+    end
+
+    stop_fn = fn _state ->
+      stop()
+    end
+
+    Stream.resource(start_fn, next_fn, stop_fn)
+  end
+
+  @spec default_extract(map()) :: {:ok, map()}
+  def default_extract(response) do
+    {:ok, response.body["data"]}
+  end
+
+  @spec default_next_page(number, map()) :: {:ok, number} | {:ok, nil}
+  def default_next_page(current_page, response) do
+    next = case response.body["links"]["next"] do
+             ^current_page -> nil
+             page -> page
+           end
+
+    {:ok, next}
+  end
+
+  defp start(fetch_page, extract_data, calc_next_page) do
+    with {:ok, response} <- fetch_page.(1),
+         {:ok, data} <- extract_data.(response),
+         {:ok, next_page_number} <- calc_next_page.(1, response) do
+      { data, next_page_number }
+    else
+      error -> { :halt, error}
+    end
+  end
+
+  defp next_item(_fetch, _extract, _next, {[], nil} = state) do
+    {:halt, state}
+  end
+
+  defp next_item(fetch_page, extract_data, calc_next_page, {[], next_page_number} = state) do
+    with {:ok, response} <- fetch_page.(next_page_number),
+         {:ok, [head | tail]} <- extract_data.(response),
+         {:ok, new_next_page_number} <- calc_next_page.(next_page_number, response) do
+      {[head], { tail, new_next_page_number }}
+    else
+      _ -> { :halt, state }
+    end
+  end
+
+  defp next_item(_fetch, _extract, _next, {[head | tail], next_page_number}) do
+    {[head], {tail, next_page_number}}
+  end
+
+  defp next_item(_fetch, _extract, _next, {:halt, _} = error), do: error
+
+  defp stop() do
+    :ok
+  end
+end

--- a/lib/streamable.ex
+++ b/lib/streamable.ex
@@ -1,4 +1,23 @@
 defmodule ExTV.Streamable do
+  @doc """
+  Sets up a stream for a paginated API call based on 3 functions;
+
+  - A function which given a page number, will call the API for the page
+  - A function which will extract the desired data from the response
+  - A function which will calculate the number of the next page from the current page and response
+
+  This module provides defaults for the last two functions: default_extract/1 and default_next_page/2
+  Errors raised when fetching a page will result in an empty enumeration.
+
+  Example:
+
+      iex> ExTV.Streamable.stream(
+      ...> fn page -> ExTV.HTTP.get("https://someapi.com/?page=#\{page\}") end,
+      ...> &ExTV.Streamable.default_extract/1,
+      ...> &ExTV.Streamable.default_next_page/2
+      ...> )
+      #Function<50.40091930/2 in Stream.resource/3>
+  """
   @spec stream((integer -> map()), (map() -> map()), (integer, map() -> integer)) :: Enumerable.t
   def stream(fetch_page, extract_data \\ &default_extract/1, calc_next_page \\ &default_next_page/2) do
     start_fn = fn ->
@@ -16,11 +35,30 @@ defmodule ExTV.Streamable do
     Stream.resource(start_fn, next_fn, stop_fn)
   end
 
+  @doc """
+  A default extraction function which will return the top level 'data' key in the response body
+
+  Example:
+      iex> ExTV.Streamable.default_extract(%{ body: %{ "data" => "Cookies" } })
+      {:ok, "Cookies"}
+  """
   @spec default_extract(map()) :: {:ok, map()}
   def default_extract(response) do
     {:ok, response.body["data"]}
   end
 
+  @doc """
+  A default function which will calculate the next page number to fetch based on the current
+  number and API response using the top level 'links' key which provides pagination info.
+  Returns nil when the final page is reached.
+
+  Example:
+      iex(4)> ExTV.Streamable.default_next_page(1, %{ body: %{ "links" => %{ "next" => 1 } } })
+      {:ok, nil}
+
+      iex(5)> ExTV.Streamable.default_next_page(1, %{ body: %{ "links" => %{ "next" => 2 } } })
+      {:ok, 2}
+  """
   @spec default_next_page(number, map()) :: {:ok, number} | {:ok, nil}
   def default_next_page(current_page, response) do
     next = case response.body["links"]["next"] do

--- a/test/series_test.exs
+++ b/test/series_test.exs
@@ -48,16 +48,18 @@ defmodule ExTV.SeriesTest do
     test "successfully fetch a series' episodes by series ID" do
       use_cassette "episodes_success" do
         result = ExTV.Series.episodes(295685)
+                 |> Enum.into([])
 
         assert List.first(result)["episodeName"] == "Pilot"
       end
     end
 
-    test "returns nil when it fails to find that series by ID" do
+    test "returns an empty enumerable when it fails to find that series by ID" do
       use_cassette "episodes_failure" do
         result = ExTV.Series.episodes(-1)
+                 |> Enum.into([])
 
-        assert result == nil
+        assert result == []
       end
     end
   end

--- a/test/streamable_test.exs
+++ b/test/streamable_test.exs
@@ -1,0 +1,56 @@
+defmodule ExTV.StreamableTest do
+  use ExUnit.Case, async: false
+
+  describe "stream/3" do
+    test "streams paginated APIs" do
+      mock_data = ["one", "two", "three"]
+
+      # Grab each element from mock_data
+      fetch_page = fn page -> {:ok, Enum.slice(mock_data, page - 1, 1)} end
+
+      # Just return the element
+      extract = fn resp -> {:ok, resp} end
+
+      # Next page is just page + 1 until the end of the list
+      next_page = fn page, _resp ->
+        next = cond do
+          page == length(mock_data) -> nil
+          true -> page + 1
+        end
+        {:ok, next}
+      end
+
+      result = ExTV.Streamable.stream(fetch_page, extract, next_page)
+               |> Enum.into([])
+
+      assert result == mock_data
+    end
+  end
+
+  describe "default_extract/1" do
+    test "returns the response body's top level 'data' key" do
+      response = %{ body: %{ "data" => [1, 2, 3] } }
+      result = ExTV.Streamable.default_extract(response)
+
+      assert result == {:ok, [1, 2, 3]}
+    end
+  end
+
+  describe "default_next_page/2" do
+    test "returns ok, nil when current page is equal to next page in response links" do
+      current_page = 1
+      response = %{ body: %{ "links" => %{ "next" => current_page } } }
+      result = ExTV.Streamable.default_next_page(current_page, response)
+
+      assert result == {:ok, nil}
+    end
+
+    test "returns ok, page when current page is not equal to next page in response links" do
+      current_page = 1
+      response = %{ body: %{ "links" => %{ "next" => current_page + 1 } } }
+      result = ExTV.Streamable.default_next_page(current_page, response)
+
+      assert result == {:ok, 2}
+    end
+  end
+end

--- a/test/streamable_test.exs
+++ b/test/streamable_test.exs
@@ -25,6 +25,31 @@ defmodule ExTV.StreamableTest do
 
       assert result == mock_data
     end
+
+    test "raises an error on soft errors when 'raise' opt is specified as true" do
+      mock_data = ["one", "two", "three"]
+
+      # Return an error
+      fetch_page = fn _page -> {:error, :no_data} end
+
+      # Just return the element
+      extract = fn resp -> {:ok, resp} end
+
+      # Next page is just page + 1 until the end of the list
+      next_page = fn page, _resp ->
+        next = cond do
+          page == length(mock_data) -> nil
+          true -> page + 1
+        end
+        {:ok, next}
+      end
+
+
+      assert_raise RuntimeError, fn ->
+        ExTV.Streamable.stream(fetch_page, extract, next_page, [raise: true])
+        |> Enum.into([])
+      end
+    end
   end
 
   describe "default_extract/1" do


### PR DESCRIPTION
## Work in progress

- [x] Add streaming module
- [x] Update documentation
- [x] Add tests
- [ ] Update rest of `series.ex`

---

Heya. I'm having a play with getting pagination going. My particular use case is to seamlessly iterate over episodes, no matter how many pages there are. I've got this in a working state so far, so you can do things like this:

```elixir
# Get all episodes
ExTV.Series.episodes(295685)
|> Enum.into([])

# Get the last 5 episodes in season 6
ExTV.Series.episodes(76290)
|> Stream.filter(&(&1["airedSeason"] == 6))
|> Enum.sort_by(&(&1["airedEpisodeNumber"]))
|> Enum.take(-5)

# and so on..
```

Assuming the API is pretty standard in how it does pagination, it should be as simple as changing each API to define a function which does a `get` given a `page`, and pass that to `ExTV.Streamable.stream/3`, as you can see in `ExTV.Series.episodes/1`.

Let me know what you think. Keen to get some feedback before I charge forward and finish the above checklist